### PR TITLE
change version string to sort properly with releases

### DIFF
--- a/rsyslog/precise/v8-stable/debian/changelog
+++ b/rsyslog/precise/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.14.0-0adiscon1precise1) precise; urgency=medium
+
+  * Packages for 8.14.0
+
+ -- Florian Riedl <friedl@adiscon.com>  Tue, 03 Nov 2015 14:03:53 +0000
+
 rsyslog (8.13.0-0adiscon1precise1) precise; urgency=medium
 
   * Packages for 8.13.0

--- a/rsyslog/trusty/v8-stable/debian/changelog
+++ b/rsyslog/trusty/v8-stable/debian/changelog
@@ -1,3 +1,9 @@
+rsyslog (8.14.0-0adiscon1trusty1) trusty; urgency=medium
+
+  * Packages for 8.14.0
+
+ -- Florian Riedl <friedl@adiscon.com>  Tue, 03 Nov 2015 14:04:37 +0000
+
 rsyslog (8.13.0-0adiscon1trusty1) trusty; urgency=medium
 
   * Packages for 8.13.0

--- a/rsyslog/vivid/v8-stable/debian/changelog
+++ b/rsyslog/vivid/v8-stable/debian/changelog
@@ -1,3 +1,15 @@
+rsyslog (8.14.0-0adiscon2vivid1) vivid; urgency=medium
+
+  * Repack for 8.14.0
+
+ -- Florian Riedl <friedl@adiscon.com>  Tue, 03 Nov 2015 14:37:08 +0000
+
+rsyslog (8.14.0-0adiscon1vivid1) vivid; urgency=medium
+
+  * Packages for 8.14.0
+
+ -- Florian Riedl <friedl@adiscon.com>  Tue, 03 Nov 2015 14:05:09 +0000
+
 rsyslog (8.13.0-0adiscon1vivid1) vivid; urgency=medium
 
   * Packages for 8.13.0

--- a/rsyslog/vivid/v8-stable/debian/control
+++ b/rsyslog/vivid/v8-stable/debian/control
@@ -13,7 +13,6 @@ Build-Depends: debhelper (>= 8),
 	       libmongo-client-dev (>= 0.1.4),
                librelp-dev (>= 1.0.2),
                libestr-dev (>= 0.1.2),
-               libee-dev (>= 0.4.0),
                liblognorm1-dev (>= 1.0.0),
 	       libjson0-dev, 
 	       libmongo-client-dev, 
@@ -25,14 +24,11 @@ Build-Depends: debhelper (>= 8),
                dh-apparmor,
 	       libcurl4-gnutls-dev,
 	       bison,
+	       libgcrypt-dev,
 	       libgt-dev,
 	       python-docutils,
+	       libsystemd-dev,
 	       liblogging-stdlog-dev,
-	       libnet-dev,
-	       librdkafka-dev,
-	       libgcrypt-dev,
-	       libksi-dev
-#	       libjemalloc-dev
 Standards-Version: 3.9.2
 XSBC-Original-Vcs-Git: git://git.debian.org/git/collab-maint/rsyslog.git
 XSBC-Original-Vcs-Browser: http://git.debian.org/?p=collab-maint/rsyslog.git;a=summary
@@ -52,7 +48,6 @@ Depends: ${shlibs:Depends},
          adduser,
          ucf,
 	 libjson0,
-	 libjemalloc1,
 	 liblogging-stdlog1,
 	 libgt0
 Recommends: logrotate
@@ -63,9 +58,6 @@ Suggests: rsyslog-mysql | rsyslog-pgsql,
           rsyslog-elasticsearch,
           rsyslog-mmjsonparse,
           rsyslog-imptcp,
-          rsyslog-gnutls,
-	  rsyslog-udpspoof,
-	  rsyslog-kafka,
           apparmor (>= 2.3)
 Description: a rocket-fast system for log processing
  Rsyslog is a multi-threaded implementation of syslogd (a system utility
@@ -227,17 +219,6 @@ Depends: ${shlibs:Depends},
          liblognorm1
 Description: Parse all fields of the message into structured data inside the JSON tree.
 
-Package: rsyslog-mmutf8fix
-Architecture: any
-Priority: extra
-Depends: ${shlibs:Depends},
-         ${misc:Depends},
-         rsyslog (= ${binary:Version}),
-Description: The mmutf8fix module permits to fix invalid UTF-8 sequences. Most often, 
- such invalid sequences result from syslog sources sending in non-UTF character sets, 
- e.g. ISO 8859. As syslog does not have a way to convey the character set information, 
- these sequences are not properly handled.
-
 Package: rsyslog-pmciscoios
 Architecture: any
 Priority: extra
@@ -245,36 +226,6 @@ Depends: ${shlibs:Depends},
          ${misc:Depends},
          rsyslog (= ${binary:Version}),
 Description: Parser module which supports various Cisco IOS formats. 
-
-Package: rsyslog-gnutls
-Architecture: any
-Priority: extra
-Depends: ${shlibs:Depends},
-         ${misc:Depends},
-         rsyslog (= ${binary:Version})
-Suggests: gnutls-bin
-Description: TLS protocol support for rsyslog
- This netstream plugin allows rsyslog to send and receive encrypted syslog
- messages via the upcoming syslog-transport-tls IETF standard protocol.
-
-Package: rsyslog-udpspoof
-Architecture: any
-Priority: extra
-Depends: ${shlibs:Depends},
-         ${misc:Depends},
-         rsyslog (= ${binary:Version}),
-         libnet-dev
-Description: This module is similar to the regular UDP forwarder, but permits to spoof the sender address.
-
-Package: rsyslog-kafka
-Architecture: any
-Priority: extra
-Depends: ${shlibs:Depends},
-         ${misc:Depends},
-         rsyslog (= ${binary:Version}),
-         librdkafka-dev
-Description: This module implements an Apache Kafka producer, permitting rsyslog to write data to Kafka.
-
 
 #Package: rsyslog-zmq
 #Architecture: any

--- a/rsyslog/vivid/v8-stable/debian/rsyslog.install
+++ b/rsyslog/vivid/v8-stable/debian/rsyslog.install
@@ -10,6 +10,7 @@ debian/tmp/usr/lib/rsyslog/impstats.so
 debian/tmp/usr/lib/rsyslog/imtcp.so
 debian/tmp/usr/lib/rsyslog/imudp.so
 debian/tmp/usr/lib/rsyslog/imuxsock.so
+debian/tmp/usr/lib/rsyslog/imjournal.so
 debian/tmp/usr/lib/rsyslog/lmnet.so
 debian/tmp/usr/lib/rsyslog/lmnetstrms.so
 debian/tmp/usr/lib/rsyslog/lmnsd_ptcp.so
@@ -20,10 +21,12 @@ debian/tmp/usr/lib/rsyslog/lmtcpsrv.so
 debian/tmp/usr/lib/rsyslog/lmzlibw.so
 debian/tmp/usr/lib/rsyslog/ommail.so
 debian/tmp/usr/lib/rsyslog/omprog.so
+debian/tmp/usr/lib/rsyslog/omjournal.so
 # debian/tmp/usr/lib/rsyslog/omruleset.so
 debian/tmp/usr/lib/rsyslog/mmpstrucdata.so
 debian/tmp/usr/lib/rsyslog/mmsequence.so
 debian/tmp/usr/lib/rsyslog/mmexternal.so
+debian/tmp/usr/lib/rsyslog/lmnsd_gtls.so
 debian/tmp/usr/lib/rsyslog/lmcry_gcry.so
 debian/tmp/usr/lib/rsyslog/lmsig_gt.so
 debian/tmp/usr/lib/rsyslog/pm*.so

--- a/rsyslog/vivid/v8-stable/debian/rules
+++ b/rsyslog/vivid/v8-stable/debian/rules
@@ -1,7 +1,5 @@
 #!/usr/bin/make -f
 
-export DEB_CFLAGS_MAINT_APPEND = -std=c99
-
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/buildflags.mk
 
@@ -28,9 +26,9 @@ override_dh_auto_configure:
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
 		--enable-omprog \
-                --enable-elasticsearch \
-                --enable-mmjsonparse \
-                --enable-imptcp \
+		--enable-elasticsearch \
+		--enable-mmjsonparse \
+		--enable-imptcp \
 		--enable-mmnormalize \
 		--enable-mmanon \
 		--enable-ommongodb \
@@ -39,15 +37,12 @@ override_dh_auto_configure:
 		--enable-mmpstrucdata \
 		--enable-mmsequence \
 		--enable-pmciscoios \
-		--enable-mmutf8fix \
-                --enable-usertools \
-		--enable-omudpspoof \
-		--enable-omkafka \
-		--enable-gt-ksi \
-                --disable-testbench \
-                --with-systemdsystemunitdir=/lib/systemd/system
+		--enable-usertools \
+		--enable-imjournal \
+		--enable-omjournal \
+		--disable-testbench \
+		--with-systemdsystemunitdir=/lib/systemd/system
 
-# unstable	                --enable-jemalloc \
 #                --enable-gssapi-krb5 \
 #                --enable-guardtime \
 #                --enable-ommongodb \

--- a/rsyslog/wily/v8-stable/debian/changelog
+++ b/rsyslog/wily/v8-stable/debian/changelog
@@ -1,3 +1,15 @@
+rsyslog (8.14.0-0adiscon2wily1) wily; urgency=medium
+
+  * Repack for 8.14.0
+
+ -- Florian Riedl <friedl@adiscon.com>  Tue, 03 Nov 2015 14:37:48 +0000
+
+rsyslog (8.14.0-0adiscon1wily1) wily; urgency=medium
+
+  * Packages for 8.14.0
+
+ -- Florian Riedl <friedl@adiscon.com>  Tue, 03 Nov 2015 14:05:46 +0000
+
 rsyslog (8.13.0-0adiscon1wily1) wily; urgency=medium
 
   * Packages for 8.13.0

--- a/rsyslog/wily/v8-stable/debian/control
+++ b/rsyslog/wily/v8-stable/debian/control
@@ -13,7 +13,6 @@ Build-Depends: debhelper (>= 8),
 	       libmongo-client-dev (>= 0.1.4),
                librelp-dev (>= 1.0.2),
                libestr-dev (>= 0.1.2),
-               libee-dev (>= 0.4.0),
                liblognorm1-dev (>= 1.0.0),
 	       libjson0-dev, 
 	       libmongo-client-dev, 
@@ -25,14 +24,11 @@ Build-Depends: debhelper (>= 8),
                dh-apparmor,
 	       libcurl4-gnutls-dev,
 	       bison,
+	       libgcrypt-dev,
 	       libgt-dev,
 	       python-docutils,
+	       libsystemd-dev,
 	       liblogging-stdlog-dev,
-	       libnet-dev,
-	       librdkafka-dev,
-	       libgcrypt-dev,
-	       libksi-dev
-#	       libjemalloc-dev
 Standards-Version: 3.9.2
 XSBC-Original-Vcs-Git: git://git.debian.org/git/collab-maint/rsyslog.git
 XSBC-Original-Vcs-Browser: http://git.debian.org/?p=collab-maint/rsyslog.git;a=summary
@@ -52,7 +48,6 @@ Depends: ${shlibs:Depends},
          adduser,
          ucf,
 	 libjson0,
-	 libjemalloc1,
 	 liblogging-stdlog1,
 	 libgt0
 Recommends: logrotate
@@ -63,9 +58,6 @@ Suggests: rsyslog-mysql | rsyslog-pgsql,
           rsyslog-elasticsearch,
           rsyslog-mmjsonparse,
           rsyslog-imptcp,
-          rsyslog-gnutls,
-	  rsyslog-udpspoof,
-	  rsyslog-kafka,
           apparmor (>= 2.3)
 Description: a rocket-fast system for log processing
  Rsyslog is a multi-threaded implementation of syslogd (a system utility
@@ -227,17 +219,6 @@ Depends: ${shlibs:Depends},
          liblognorm1
 Description: Parse all fields of the message into structured data inside the JSON tree.
 
-Package: rsyslog-mmutf8fix
-Architecture: any
-Priority: extra
-Depends: ${shlibs:Depends},
-         ${misc:Depends},
-         rsyslog (= ${binary:Version}),
-Description: The mmutf8fix module permits to fix invalid UTF-8 sequences. Most often, 
- such invalid sequences result from syslog sources sending in non-UTF character sets, 
- e.g. ISO 8859. As syslog does not have a way to convey the character set information, 
- these sequences are not properly handled.
-
 Package: rsyslog-pmciscoios
 Architecture: any
 Priority: extra
@@ -245,36 +226,6 @@ Depends: ${shlibs:Depends},
          ${misc:Depends},
          rsyslog (= ${binary:Version}),
 Description: Parser module which supports various Cisco IOS formats. 
-
-Package: rsyslog-gnutls
-Architecture: any
-Priority: extra
-Depends: ${shlibs:Depends},
-         ${misc:Depends},
-         rsyslog (= ${binary:Version})
-Suggests: gnutls-bin
-Description: TLS protocol support for rsyslog
- This netstream plugin allows rsyslog to send and receive encrypted syslog
- messages via the upcoming syslog-transport-tls IETF standard protocol.
-
-Package: rsyslog-udpspoof
-Architecture: any
-Priority: extra
-Depends: ${shlibs:Depends},
-         ${misc:Depends},
-         rsyslog (= ${binary:Version}),
-         libnet-dev
-Description: This module is similar to the regular UDP forwarder, but permits to spoof the sender address.
-
-Package: rsyslog-kafka
-Architecture: any
-Priority: extra
-Depends: ${shlibs:Depends},
-         ${misc:Depends},
-         rsyslog (= ${binary:Version}),
-         librdkafka-dev
-Description: This module implements an Apache Kafka producer, permitting rsyslog to write data to Kafka.
-
 
 #Package: rsyslog-zmq
 #Architecture: any

--- a/rsyslog/wily/v8-stable/debian/rsyslog.install
+++ b/rsyslog/wily/v8-stable/debian/rsyslog.install
@@ -10,6 +10,7 @@ debian/tmp/usr/lib/rsyslog/impstats.so
 debian/tmp/usr/lib/rsyslog/imtcp.so
 debian/tmp/usr/lib/rsyslog/imudp.so
 debian/tmp/usr/lib/rsyslog/imuxsock.so
+debian/tmp/usr/lib/rsyslog/imjournal.so
 debian/tmp/usr/lib/rsyslog/lmnet.so
 debian/tmp/usr/lib/rsyslog/lmnetstrms.so
 debian/tmp/usr/lib/rsyslog/lmnsd_ptcp.so
@@ -20,10 +21,12 @@ debian/tmp/usr/lib/rsyslog/lmtcpsrv.so
 debian/tmp/usr/lib/rsyslog/lmzlibw.so
 debian/tmp/usr/lib/rsyslog/ommail.so
 debian/tmp/usr/lib/rsyslog/omprog.so
+debian/tmp/usr/lib/rsyslog/omjournal.so
 # debian/tmp/usr/lib/rsyslog/omruleset.so
 debian/tmp/usr/lib/rsyslog/mmpstrucdata.so
 debian/tmp/usr/lib/rsyslog/mmsequence.so
 debian/tmp/usr/lib/rsyslog/mmexternal.so
+debian/tmp/usr/lib/rsyslog/lmnsd_gtls.so
 debian/tmp/usr/lib/rsyslog/lmcry_gcry.so
 debian/tmp/usr/lib/rsyslog/lmsig_gt.so
 debian/tmp/usr/lib/rsyslog/pm*.so

--- a/rsyslog/wily/v8-stable/debian/rules
+++ b/rsyslog/wily/v8-stable/debian/rules
@@ -1,7 +1,5 @@
 #!/usr/bin/make -f
 
-export DEB_CFLAGS_MAINT_APPEND = -std=c99
-
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/buildflags.mk
 
@@ -28,9 +26,9 @@ override_dh_auto_configure:
 		--enable-pmrfc3164sd \
 		--enable-pmsnare \
 		--enable-omprog \
-                --enable-elasticsearch \
-                --enable-mmjsonparse \
-                --enable-imptcp \
+		--enable-elasticsearch \
+		--enable-mmjsonparse \
+		--enable-imptcp \
 		--enable-mmnormalize \
 		--enable-mmanon \
 		--enable-ommongodb \
@@ -39,15 +37,12 @@ override_dh_auto_configure:
 		--enable-mmpstrucdata \
 		--enable-mmsequence \
 		--enable-pmciscoios \
-		--enable-mmutf8fix \
-                --enable-usertools \
-		--enable-omudpspoof \
-		--enable-omkafka \
-		--enable-gt-ksi \
-                --disable-testbench \
-                --with-systemdsystemunitdir=/lib/systemd/system
+		--enable-usertools \
+		--enable-imjournal \
+		--enable-omjournal \
+		--disable-testbench \
+		--with-systemdsystemunitdir=/lib/systemd/system
 
-# unstable	                --enable-jemalloc \
 #                --enable-gssapi-krb5 \
 #                --enable-guardtime \
 #                --enable-ommongodb \

--- a/scripts/auto_daily_project.sh
+++ b/scripts/auto_daily_project.sh
@@ -26,7 +26,7 @@ ls -l *.tar.gz # debug output
 szSourceFile=`ls *.tar.gz`
 szSourceBase=`basename $szSourceFile .tar.gz`
 VERSION=`echo $szSourceBase|cut -d- -f2`
-LAUNCHPAD_VERSION=`echo $VERSION|cut -d. -f1-3`.`date +%Y%m%d%H%M%S`
+LAUNCHPAD_VERSION=`echo $VERSION|cut -d. -f1-3`.'0aa'.`date +%Y%m%d%H%M%S`
 PROJECT=`echo $szSourceBase | cut -d- -f1`
 szReplaceFile="${PROJECT}_$LAUNCHPAD_VERSION"
 VERSION_FILE="LAST_VERSION.$szBranch.$szPlatform"


### PR DESCRIPTION
the release packages are $version.0adiscon1$branch-$arch, $version is changed immediatly after the release of the prior version, and the year sorts after 0adiscon, so when the final release of $version happens, it won't automatically replace dev packages.

by inserting '0aa.' before the date, the development versions will sort before the final release and be replaced by the final release when it ships.
